### PR TITLE
Fix crash when accessing non-string properties

### DIFF
--- a/windows/wmi_utils.h
+++ b/windows/wmi_utils.h
@@ -41,6 +41,8 @@ std::vector<std::wstring> _exec(IWbemServices *pSvc, std::string tableName,
                                 std::string fieldName,
                                 std::string condition = "");
 
+std::wstring _vtToString(VARIANT &vtProp);
+
 } // namespace WmiUtils
 
 #endif // WMI_UTILS_H


### PR DESCRIPTION
## Problem
The WMI plugin crashed instantly when trying to access integer, boolean, or other non-string properties. This was caused by incorrectly casting all VARIANT types to bstrVal (string), leading to invalid pointer dereferences.

## Fix
- Added proper type checking before casting VARIANT values
- Created a single `_vtToString()` function to handle all data types
- Now supports: integers (signed/unsigned), floats, booleans, dates, and strings
- Eliminated code duplication across multiple functions

## Impact
**Before**: App crashes when accessing non-string WMI properties  
**After**: All basic WMI data types work correctly

<details>
<summary><h2>Demo</h2></summary>
<h3>Before: </h3>
<p>Crashes</p>

https://github.com/user-attachments/assets/20b38ae1-c9fa-42ab-b188-74f2fdffd8e5

<h3>After: </h3>
<p>Fixed</p>

https://github.com/user-attachments/assets/d0511ce2-90f3-4a6c-9bfa-afc95a29a434

</details>

<details>
<summary><h2>Reproducible Test Code</h2></summary>

```dart
import 'package:flutter/material.dart';
import 'package:wmi/wmi.dart';

void main() {
  runApp(const MainApp());
}

class MainApp extends StatefulWidget {
  const MainApp({super.key});

  @override
  State<MainApp> createState() => _MainAppState();
}

class _MainAppState extends State<MainApp> {
  final _wmiPlugin = Wmi();
  bool _wmiInitialized = false;

  String _fieldName = '';
  String _tableName = '';
  String _value = '';

  @override
  void initState() {
    super.initState();
    initWmi();
  }

  Future<void> initWmi() async {
    try {
      _wmiInitialized = await _wmiPlugin.wmiInit() ?? false;
    } catch (e) {
      debugPrint('Failed wmiInit(), error: $e');
    }
  }

  @override
  void dispose() {
    if (_wmiInitialized) _wmiPlugin.wmiRelease();
    super.dispose();
  }

  Future<void> _getValue(String fieldName, String tableName) async {
    if (!_wmiInitialized) return;

    _fieldName = fieldName;
    _tableName = tableName;

    try {
      _value =
          await _wmiPlugin.wmiValue(fieldname: _fieldName, tablename: _tableName) ??
          'Unknown';
    } catch (e) {
      _value = 'Failed to get $_fieldName from $_tableName, error: $e';
    }

    if (mounted) setState(() {});
  }

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
        body: Column(
          children: [
            Text('Field: $_fieldName'),
            Text('Table: $_tableName'),
            Text('Value: $_value'),
            Text('!! means crash'),
            Wrap(
              spacing: 10,
              runSpacing: 10,
              children: [
                ElevatedButton(
                  onPressed: () => _getValue('DaylightName', 'Win32_TimeZone'),
                  child: const Text('Daylight Name (string)'),
                ),
                ElevatedButton(
                  onPressed: () => _getValue('StandardDayOfWeek', 'Win32_TimeZone'),
                  child: const Text('Day of Week (uint8) !!'),
                ),
                ElevatedButton(
                  onPressed: () => _getValue('OSType', 'Win32_OperatingSystem'),
                  child: const Text('OS Type (uint16) !!'),
                ),
                ElevatedButton(
                  onPressed: () => _getValue('OSLanguage', 'Win32_OperatingSystem'),
                  child: const Text('OS Language (uint32) !!'),
                ),
                ElevatedButton(
                  onPressed: () =>
                      _getValue('TotalVisibleMemorySize', 'Win32_OperatingSystem'),
                  child: const Text('Memory Size (uint64)'),
                ),
                ElevatedButton(
                  onPressed: () =>
                      _getValue('VirtualizationFirmwareEnabled', 'Win32_Processor'),
                  child: const Text('Virtualization (bool) !!'),
                ),
                ElevatedButton(
                  onPressed: () => _getValue('LastBootUpTime', 'Win32_OperatingSystem'),
                  child: const Text('Last boot (datetime)'),
                ),
                ElevatedButton(
                  onPressed: () => _getValue('CurrentTimeZone', 'Win32_OperatingSystem'),
                  child: const Text('Current Time Zone (sint16) !!'),
                ),
                ElevatedButton(
                  onPressed: () => _getValue('Bias', 'Win32_TimeZone'),
                  child: const Text('Bias (sint32) !!'),
                ),
              ],
            ),
          ],
        ),
      ),
    );
  }
}
```

</details>